### PR TITLE
Feature/markdown preview

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,7 @@
 
 require'plugins'
 require'mappings'
+require'settings.markdown'
 -- --------------------------------------------
 -- --------------------------------------------
 -- Basic

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -120,3 +120,13 @@ vim.keymap.set("n", "<Leader>fb", require("telescope.builtin").buffers, { desc =
 
 -- 全文検索
 vim.keymap.set("n", "<Leader>fg", require("telescope.builtin").live_grep, { desc = "全文検索 (live grep)" })
+
+
+-- --------------------------------------------
+-- markdown-preview.nvim
+-- --------------------------------------------
+
+-- <Leader> + mp でブラウザでMarkdownPreview
+vim.keymap.set("n", "<Leader>mp", ":MarkdownPreview<CR>", { noremap = true, silent = true })
+-- <Leader> + ms でブラウザでのMarkdownPreviewをStop
+vim.keymap.set("n", "<Leader>ms", ":MarkdownPreviewStop<CR>", { noremap = true, silent = true })

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -11,8 +11,8 @@
 vim.cmd[[packadd packer.nvim]]
 
 require("packer").startup(function(use)
--- opt オプションを付けると遅延読み込み 
--- opt = true　は使用されるタイミングで読み込まれる
+    -- opt オプションを付けると遅延読み込み 
+    -- opt = true　は使用されるタイミングで読み込まれる
     use{'wbthomason/packer.nvim'}
     use{"lambdalisue/fern.vim"}
     use{'neovim/nvim-lspconfig'}
@@ -21,15 +21,22 @@ require("packer").startup(function(use)
     use{'hrsh7th/nvim-cmp'}
     use{'hrsh7th/cmp-nvim-lsp'}
     use{'hrsh7th/vim-vsnip'}
-    use { 'stevearc/conform.nvim' }  -- フォーマッタ対応
-    use {
+    use{ 'stevearc/conform.nvim' }  -- フォーマッタ対応
+    use{
         'nvim-telescope/telescope.nvim',
         tag = '0.1.8',
         requires = { {'nvim-lua/plenary.nvim'} }
     }
+    use({
+        "iamcco/markdown-preview.nvim",
+        run = "cd app && npm install",
+        cmd = { "MarkdownPreview", "MarkdownPreviewStop", "MarkdownPreviewToggle" }})
+
 end)
 
 -- プラグインを追加したり更新した時は以下のコマンドをコマンドラインモードで実行する
+--
+--
 -- PackerInstall
 -- PackerSync
 

--- a/lua/settings/markdown.lua
+++ b/lua/settings/markdown.lua
@@ -1,0 +1,8 @@
+-- settings/markdown.lua
+
+-- markdown-preview.nvim 設定
+vim.g.mkdp_auto_start = 0          -- ファイルを開いたとき自動でプレビューしない
+vim.g.mkdp_auto_close = 1          -- Markdownバッファを閉じたらプレビューも閉じる
+vim.g.mkdp_open_to_the_world = 0   -- ローカルアクセスのみ
+vim.g.mkdp_browser = ""            -- デフォルトブラウザを使用
+vim.g.mkdp_theme = "dark"          -- テーマは "dark"


### PR DESCRIPTION
## 概要

Neovim に Markdown Preview 機能を追加しました。`iamcco/markdown-preview.nvim` を導入し、プレビューをブラウザで確認できるようになりました。

---

## 変更内容

- `markdown-preview.nvim` を Packer に追加  
  - `run = "cd app && npm install"` により初回セットアップも対応
- `settings/markdown.lua` に以下の設定を追加  
  - 自動起動オフ（`mkdp_auto_start = 0`）
  - バッファクローズ時に自動停止（`mkdp_auto_close = 1`）
  - ダークテーマ指定（`mkdp_theme = "dark"`）
- キーマッピング追加（Normalモード）  
  - `<Leader>mp` で `:MarkdownPreview` 起動  
  - `<Leader>ms` で `:MarkdownPreviewStop` 停止

---

## 使用方法

1. Markdown ファイルを開く  
2. 以下のキーマッピングを使用：

| キー         | コマンド               | 説明                    |
|--------------|------------------------|-------------------------|
| `<Leader>mp` | `:MarkdownPreview`     | プレビューを起動する   |
| `<Leader>ms` | `:MarkdownPreviewStop` | プレビューを停止する   |

---

## 補足

- 初回実行時に `npm install` により依存をインストールします（packerの`run`オプションにより自動実行）
- `vim.g.mapleader = " "` が設定済みであることを前提としています